### PR TITLE
Restyle table pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,10 +56,5 @@ onMounted(() => {
   width: 100%;
   @include flex-container;
   justify-content: space-between;
-
-  .app__main-section {
-    flex: 1;
-    background-color: var(--clr__app-main-bg);
-  }
 }
 </style>

--- a/src/components/AppPagination/AppPagination.vue
+++ b/src/components/AppPagination/AppPagination.vue
@@ -89,45 +89,48 @@ function goToSelectedPage(event: { target: { value: string } }): void {
 </script>
 
 <style scoped lang="scss">
-.app-pagination__wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--clr-text);
-  max-height: 3.8rem;
-}
 .app-pagination {
-  display: flex;
-  flex-flow: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  list-style-type: none;
-  justify-content: center;
-  color: var(--clr-text);
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
+  color: var(--clr-text);
+  list-style-type: none;
 }
+
+.app-pagination__wrapper {
+  max-height: 3.8rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--clr__azureish-white);
+}
+
 .app-pagination__control {
+  width: 3.6rem;
+  height: 3.6rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border: 0.1rem solid var(--clr__input-border);
-  fill: var(--clr__input-border);
+  fill: var(--clr__white);
+
   &--active {
+    fill: var(--clr__azureish-white);
     cursor: pointer;
-    border: 0.1rem solid var(--clr__action);
-    fill: var(--clr__action);
+
     svg {
-      fill: var(--clr__action);
+      fill: var(--clr__white);
       transition: all 0.5s ease;
     }
+
     &:hover {
+      background-color: var(--clr__azureish-white);
+
       svg {
-        fill: var(--clr__btn-hover);
+        fill: var(--clr__secondary);
       }
-      border-color: var(--clr__btn-hover);
     }
   }
 }
@@ -138,7 +141,7 @@ function goToSelectedPage(event: { target: { value: string } }): void {
   width: 1rem;
   height: 1.2rem;
   margin: 0 0.2rem;
-  fill: var(--clr__input-border);
+  fill: var(--clr__white);
 }
 
 .app-pagination__total-page {
@@ -150,16 +153,23 @@ function goToSelectedPage(event: { target: { value: string } }): void {
   margin: 0 0.8rem;
 }
 
+.app-pagination__border {
+  min-width: 2.6rem;
+  height: 3.6rem;
+  margin: 0 0.2rem;
+  background: var(--clr__secondary);
+  border-radius: 0.4rem;
+}
+
 .app-pagination__input {
-  border: 0.1rem solid var(--clr__input-border);
   width: 6rem;
   height: 3.6rem;
   margin: 0 0.2rem;
+  border: none;
   border-radius: 0.4rem;
+  background-color: var(--clr__azureish-white);
+  color: var(--clr__primary);
   text-align: center;
-  &:hover {
-    border: 0.1rem solid var(--clr__action);
-  }
 }
 
 .rotate-right {
@@ -168,13 +178,5 @@ function goToSelectedPage(event: { target: { value: string } }): void {
 
 .rotate-left {
   transform: translateX(-0.3rem) rotate(0deg);
-}
-
-.app-pagination__border {
-  background: var(--clr__main-bg);
-  border-radius: 0.4rem;
-  margin: 0 0.2rem;
-  min-width: 2.6rem;
-  height: 3.6rem;
 }
 </style>

--- a/src/components/tabs/AppTabs.vue
+++ b/src/components/tabs/AppTabs.vue
@@ -59,7 +59,7 @@ export default defineComponent({
   overflow: auto;
 }
 .app-tabs__header-item {
-  padding: 1.2rem;
+  padding: 1.2rem 2.7rem;
   font-size: 1.6rem;
   white-space: nowrap;
   border-bottom: 0.2rem solid var(--clr__table-head);
@@ -67,6 +67,7 @@ export default defineComponent({
 
   &.selected {
     font-weight: 600;
+    background-color: var(--clr__dark);
     border-bottom: 0.2rem solid var(--clr__action);
   }
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -5,6 +5,7 @@ $clr-white: #ffffff;
 $clr-dark: #111111;
 $clr-text-muted: #6c757d;
 $clr-light-gray: #ced4da;
+$clr-azureish-white: #dadef9;
 
 $clr-main-bg: #ffffff;
 $clr-splash-bg: #66b0ff;
@@ -95,4 +96,4 @@ $clr-frame-border: #e1e5e9;
 $clr-frame-box-shadow: #00000029;
 
 // Vue Skeleton Loader
-$clr-vue-skeleton-loader-bg: #e1e5e9;
+$clr-vue-skeleton-loader-bg: #6c757d;

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -3,5 +3,5 @@
 body,
 html {
   font-family: 'Atlas Grotesk Web Regular', sans-serif;
-  color: $clr-text;
+  color: $clr-white;
 }

--- a/src/styles/root.scss
+++ b/src/styles/root.scss
@@ -3,6 +3,7 @@
   --clr__secondary: #{$clr-secondary};
   --clr__white: #{$clr-white};
   --clr__dark: #{$clr-dark};
+  --clr__azureish-white: #{$clr-azureish-white};
 
   --clr__main-bg: #{$clr-main-bg};
   --clr__splash-bg: #{$clr-splash-bg};
@@ -10,7 +11,7 @@
   --clr__text: #{$clr-primary};
   --clr__text-muted: #{$clr-text-muted};
   --clr__text-on-action: #{$clr-text-on-action};
-  --clr__action: #{$clr-action};
+  --clr__action: #{$clr-secondary};
   --clr__action-disabled: #{$clr-action-disabled};
   --clr__danger: #{$clr-danger};
   --clr__action-extra-muted: #{$clr-action-extra-muted};
@@ -59,7 +60,7 @@
 
   // Progressbar
   --clr__progressbar-track: #{$clr-progressbar-track};
-  --clr__progressbar-positive: #{$clr-progressbar-positive};
+  --clr__progressbar-positive: #{$clr-secondary};
   --clr__progressbar-negative: #{$clr-progressbar-negative};
 
   // Status

--- a/src/styles/tables.scss
+++ b/src/styles/tables.scss
@@ -1,6 +1,5 @@
 .app-table {
   display: block;
-  background-color: var(--clr__white);
   border: 0.1rem solid var(--clr__light-gray);
   border-radius: 1.6rem;
 
@@ -54,6 +53,7 @@
     &-tag {
       padding: 0.4rem 1rem;
       background-color: var(--clr__azureish-white);
+      color: var(--clr__text);
       border-radius: 0.4rem;
     }
 

--- a/src/styles/views.scss
+++ b/src/styles/views.scss
@@ -1,12 +1,4 @@
 .app {
-  &__main-section {
-    padding-top: 3rem;
-    padding-bottom: 6.4rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-  }
-
   &__container {
     width: 100%;
     max-width: 140rem;
@@ -58,6 +50,13 @@
       align-items: flex-start;
     }
   }
+}
+
+.app__main-section {
+  padding-top: 3rem;
+  padding-bottom: 6.4rem;
+  background-color: var(--clr__primary);
+  @include flex-container;  
 }
 
 .app__main-view-table-header {

--- a/src/views/ValidatorsView.vue
+++ b/src/views/ValidatorsView.vue
@@ -5,7 +5,7 @@
   >
     <div class="app__main-view-table-header">
       <div class="app__main-view-table-header-prefix">
-        <span>Va</span>
+        <span>Vd</span>
       </div>
       <div class="app__main-view-table-header-info">
         <h3 class="app__main-view-table-header-info-title">Validators</h3>
@@ -320,34 +320,38 @@ onUnmounted(async () => {
 .validators-view__filter-search {
   display: flex;
   align-items: center;
-  background-color: var(--clr__light-gray-1);
+  background-color: var(--clr__dark);
   border-radius: 0.8rem;
-  color: var(--clr__input-border);
   transition: all 0.5s ease;
 
   svg {
     transition: all 0.5s ease;
-    fill: var(--clr__text-muted);
+    fill: var(--clr__white);
   }
+
   &:hover,
   &:active,
   &:focus,
   &:focus-within {
-    color: var(--clr__text);
-    border-color: var(--clr__text);
+    color: var(--clr__white);
+    border-color: var(--clr__white);
+
     svg {
       fill: var(--clr__text);
     }
   }
+
   &:disabled {
     border-color: var(--clr__input-border);
     color: var(--clr__input-border);
+
     svg {
       fill: var(--clr__input-border);
     }
   }
+
   svg.validators__filter-search-clear-btn-icon {
-    fill: var(--clr__text-muted);
+    fill: var(--clr__white);
   }
 }
 .validators-view__filter-search-input-wrapper {


### PR DESCRIPTION
Update layout for the following pages:
- Transactions
- Blocks
- Validators
- Top accounts

<img width="1728" alt="Screenshot 2022-08-24 at 22 24 04" src="https://user-images.githubusercontent.com/92103935/186506163-4f7bae5b-62a4-4c49-97ea-1c41407d0b87.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 19" src="https://user-images.githubusercontent.com/92103935/186506170-59c920e3-c9f1-4a4e-b494-bcadfecf3f43.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 31" src="https://user-images.githubusercontent.com/92103935/186506172-739015d8-7126-4857-b215-411c0215467e.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 43" src="https://user-images.githubusercontent.com/92103935/186506177-89f0ef74-1608-42ec-b35c-e13216018f2d.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 52" src="https://user-images.githubusercontent.com/92103935/186506179-9ec85e55-86f0-4c60-9cec-b51e5e055c0d.png">
