### PR TITLE
Restyle table pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,10 +56,5 @@ onMounted(() => {
   width: 100%;
   @include flex-container;
   justify-content: space-between;
-
-  .app__main-section {
-    flex: 1;
-    background-color: var(--clr__app-main-bg);
-  }
 }
 </style>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -117,10 +117,6 @@ import { START_VALUE } from '@/api/api-config'
     align-items: flex-start;
     padding: 1.2rem 0;
     margin-right: 0;
-    border-top: 0.1rem solid var(--clr__footer-border);
-    &:last-child {
-      border-bottom: 0.1rem solid var(--clr__footer-border);
-    }
   }
   .app-footer__nav-img-item {
     margin-right: 3.2rem;

--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -222,7 +222,7 @@ const isMainnet = computed(() => {
     background: var(--clr__dark);
     width: 100%;
     z-index: 1;
-    height: calc(100vh - 8.4rem);
+    height: calc(100vh - 7.6rem);
     padding: 2.4rem 1.6rem;
     border-top: 0.1rem solid var(--clr__white);
   }

--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -241,7 +241,6 @@ const isMainnet = computed(() => {
   .app-nav__link {
     width: 100%;
     padding: 2.4rem 1.2rem;
-    border-bottom: 0.1rem solid var(--clr__white);
     > span {
       text-align: left;
     }

--- a/src/components/AppPagination/AppPagination.vue
+++ b/src/components/AppPagination/AppPagination.vue
@@ -89,45 +89,48 @@ function goToSelectedPage(event: { target: { value: string } }): void {
 </script>
 
 <style scoped lang="scss">
-.app-pagination__wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--clr-text);
-  max-height: 3.8rem;
-}
 .app-pagination {
-  display: flex;
-  flex-flow: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  list-style-type: none;
-  justify-content: center;
-  color: var(--clr-text);
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
+  color: var(--clr-text);
+  list-style-type: none;
 }
+
+.app-pagination__wrapper {
+  max-height: 3.8rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--clr__azureish-white);
+}
+
 .app-pagination__control {
+  width: 3.6rem;
+  height: 3.6rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 3.6rem;
-  height: 3.6rem;
-  border: 0.1rem solid var(--clr__input-border);
-  fill: var(--clr__input-border);
+  fill: var(--clr__white);
+
   &--active {
+    fill: var(--clr__azureish-white);
     cursor: pointer;
-    border: 0.1rem solid var(--clr__action);
-    fill: var(--clr__action);
+
     svg {
-      fill: var(--clr__action);
+      fill: var(--clr__white);
       transition: all 0.5s ease;
     }
+
     &:hover {
+      background-color: var(--clr__azureish-white);
+
       svg {
-        fill: var(--clr__btn-hover);
+        fill: var(--clr__secondary);
       }
-      border-color: var(--clr__btn-hover);
     }
   }
 }
@@ -138,7 +141,7 @@ function goToSelectedPage(event: { target: { value: string } }): void {
   width: 1rem;
   height: 1.2rem;
   margin: 0 0.2rem;
-  fill: var(--clr__input-border);
+  fill: var(--clr__white);
 }
 
 .app-pagination__total-page {
@@ -150,16 +153,23 @@ function goToSelectedPage(event: { target: { value: string } }): void {
   margin: 0 0.8rem;
 }
 
+.app-pagination__border {
+  min-width: 2.6rem;
+  height: 3.6rem;
+  margin: 0 0.2rem;
+  background: var(--clr__secondary);
+  border-radius: 0.4rem;
+}
+
 .app-pagination__input {
-  border: 0.1rem solid var(--clr__input-border);
   width: 6rem;
   height: 3.6rem;
   margin: 0 0.2rem;
+  border: none;
   border-radius: 0.4rem;
+  background-color: var(--clr__azureish-white);
+  color: var(--clr__primary);
   text-align: center;
-  &:hover {
-    border: 0.1rem solid var(--clr__action);
-  }
 }
 
 .rotate-right {
@@ -168,13 +178,5 @@ function goToSelectedPage(event: { target: { value: string } }): void {
 
 .rotate-left {
   transform: translateX(-0.3rem) rotate(0deg);
-}
-
-.app-pagination__border {
-  background: var(--clr__main-bg);
-  border-radius: 0.4rem;
-  margin: 0 0.2rem;
-  min-width: 2.6rem;
-  height: 3.6rem;
 }
 </style>

--- a/src/components/LinksDropdown.vue
+++ b/src/components/LinksDropdown.vue
@@ -101,7 +101,6 @@ const isRedirect = () => {
   .link-dropdown {
     width: 100%;
     padding: 0.8rem 0;
-    border-bottom: 0.1rem solid var(--clr__white);
   }
 
   .link-dropdown__title-wrapper {

--- a/src/components/TxLine.vue
+++ b/src/components/TxLine.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="app-table__row">
     <div class="app-table__cell">
-      <span class="app-table__title">Transaction hash</span>
+      <span class="app-table__title">Transaction Hash</span>
       <TitledLink
         :name="{
           name: $routes.transactionDetails,
@@ -29,7 +29,7 @@
       />
     </div>
     <div class="app-table__cell">
-      <span class="app-table__title">Date and time</span>
+      <span class="app-table__title">Date</span>
       <span class="app-table__cell-date">
         {{ $fDate(transition.time, 'dd/MM/yy') }}
       </span>
@@ -94,3 +94,19 @@ const amountCellClass = computed(() => {
   return 'app-table__cell-tag'
 })
 </script>
+
+<style lang="scss" scoped>
+@include respond-to(medium) {
+  .app-table__title {
+    display: inline-block;
+    min-width: 15rem;
+    margin-right: 2.4rem;
+    font-weight: 300;
+  }
+
+  .app-table__row {
+    grid: none;
+    padding: 3.4rem 0 1.6rem;
+  }
+}
+</style>

--- a/src/components/TxLine.vue
+++ b/src/components/TxLine.vue
@@ -65,13 +65,13 @@
     </div>
     <div class="app-table__cell">
       <span class="app-table__title">Transaction Fee</span>
-      <span class="app-table__cell-txt">
+      <span class="app-table__cell-txt" :title="transition.fee">
         {{ transition.fee }}
       </span>
     </div>
     <div class="app-table__cell">
       <span class="app-table__title">Amount</span>
-      <span :class="[amountCellClass]">
+      <span :class="[amountCellClass]" :title="transition.amount">
         {{ transition.amount }}
       </span>
     </div>

--- a/src/components/tabs/AppTabs.vue
+++ b/src/components/tabs/AppTabs.vue
@@ -59,7 +59,7 @@ export default defineComponent({
   overflow: auto;
 }
 .app-tabs__header-item {
-  padding: 1.2rem;
+  padding: 1.2rem 2.7rem;
   font-size: 1.6rem;
   white-space: nowrap;
   border-bottom: 0.2rem solid var(--clr__table-head);

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -5,6 +5,7 @@ $clr-white: #ffffff;
 $clr-dark: #111111;
 $clr-text-muted: #6c757d;
 $clr-light-gray: #ced4da;
+$clr-azureish-white: #dadef9;
 
 $clr-main-bg: #ffffff;
 $clr-splash-bg: #66b0ff;
@@ -95,4 +96,4 @@ $clr-frame-border: #e1e5e9;
 $clr-frame-box-shadow: #00000029;
 
 // Vue Skeleton Loader
-$clr-vue-skeleton-loader-bg: #e1e5e9;
+$clr-vue-skeleton-loader-bg: #6c757d;

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -3,5 +3,5 @@
 body,
 html {
   font-family: 'Atlas Grotesk Web Regular', sans-serif;
-  color: $clr-text;
+  color: $clr-white;
 }

--- a/src/styles/root.scss
+++ b/src/styles/root.scss
@@ -3,6 +3,7 @@
   --clr__secondary: #{$clr-secondary};
   --clr__white: #{$clr-white};
   --clr__dark: #{$clr-dark};
+  --clr__azureish-white: #{$clr-azureish-white};
 
   --clr__main-bg: #{$clr-main-bg};
   --clr__splash-bg: #{$clr-splash-bg};
@@ -10,7 +11,7 @@
   --clr__text: #{$clr-primary};
   --clr__text-muted: #{$clr-text-muted};
   --clr__text-on-action: #{$clr-text-on-action};
-  --clr__action: #{$clr-action};
+  --clr__action: #{$clr-secondary};
   --clr__action-disabled: #{$clr-action-disabled};
   --clr__danger: #{$clr-danger};
   --clr__action-extra-muted: #{$clr-action-extra-muted};
@@ -59,7 +60,7 @@
 
   // Progressbar
   --clr__progressbar-track: #{$clr-progressbar-track};
-  --clr__progressbar-positive: #{$clr-progressbar-positive};
+  --clr__progressbar-positive: #{$clr-secondary};
   --clr__progressbar-negative: #{$clr-progressbar-negative};
 
   // Status

--- a/src/styles/tables.scss
+++ b/src/styles/tables.scss
@@ -31,10 +31,10 @@
     padding: 1.4rem 0;
     border-top: 0.1rem solid var(--clr__light-gray);
     font-size: 1.4rem;
-  }
 
-  .app-table__row:first-child {
-    border-top: none;
+    &:first-child {
+      border: none;
+    }
   }
 
   &__cell {
@@ -94,7 +94,7 @@
     minmax(8rem, 5fr)
     minmax(8rem, 2fr)
     minmax(8rem, 2fr)
-    minmax(8rem, 1.5fr);
+    minmax(8rem, 2fr);
 }
 
 .validators-view__table-head,

--- a/src/styles/tables.scss
+++ b/src/styles/tables.scss
@@ -1,6 +1,5 @@
 .app-table {
   display: block;
-  background-color: var(--clr__white);
   border: 0.1rem solid var(--clr__light-gray);
   border-radius: 1.6rem;
 
@@ -54,6 +53,7 @@
     &-tag {
       padding: 0.4rem 1rem;
       background-color: var(--clr__azureish-white);
+      color: var(--clr__text);
       border-radius: 0.4rem;
     }
 

--- a/src/styles/views.scss
+++ b/src/styles/views.scss
@@ -1,12 +1,4 @@
 .app {
-  &__main-section {
-    padding-top: 3rem;
-    padding-bottom: 6.4rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-  }
-
   &__container {
     width: 100%;
     max-width: 140rem;
@@ -58,6 +50,13 @@
       align-items: flex-start;
     }
   }
+}
+
+.app__main-section {
+  padding-top: 3rem;
+  padding-bottom: 6.4rem;
+  background-color: var(--clr__primary);
+  @include flex-container;  
 }
 
 .app__main-view-table-header {

--- a/src/views/BlocksList.vue
+++ b/src/views/BlocksList.vue
@@ -43,7 +43,7 @@
               />
             </div>
             <div class="app-table__cell">
-              <span class="app-table__title">Date and time</span>
+              <span class="app-table__title">Date</span>
               <span class="app-table__cell-date">
                 {{ $fDate(item.header.time, 'dd/MM/yy') }}
               </span>

--- a/src/views/TopAccounts.vue
+++ b/src/views/TopAccounts.vue
@@ -26,25 +26,27 @@
         <span>ODIN token percentage</span>
         <span>Transaction count</span>
       </div>
-      <template v-if="accounts?.length">
-        <AccountsLine
-          v-for="(item, index) in filteredAccounts"
-          :key="index"
-          :account="item"
-          :rank="(+currentPage - 1) * +ITEMS_PER_PAGE + (index + 1)"
-        />
-      </template>
-      <template v-else>
-        <SkeletonTable
-          v-if="isLoading"
-          :header-titles="headerTitles"
-          table-size="10"
-          class-string="accounts-line"
-        />
-        <div v-else class="app-table__empty-stub">
-          <p class="empty mg-t32">No items yet</p>
-        </div>
-      </template>
+      <div>
+        <template v-if="accounts?.length">
+          <AccountsLine
+            v-for="(item, index) in filteredAccounts"
+            :key="index"
+            :account="item"
+            :rank="(+currentPage - 1) * +ITEMS_PER_PAGE + (index + 1)"
+          />
+        </template>
+        <template v-else>
+          <SkeletonTable
+            v-if="isLoading"
+            :header-titles="headerTitles"
+            table-size="10"
+            class-string="accounts-line"
+          />
+          <div v-else class="app-table__empty-stub">
+            <p class="empty mg-t32">No items yet</p>
+          </div>
+        </template>
+      </div>
     </div>
     <AppPagination
       v-if="accounts.length > ITEMS_PER_PAGE"
@@ -120,15 +122,6 @@ onMounted(async (): Promise<void> => {
 .top-accounts__sort-field {
   display: flex;
   align-items: center;
-}
-.top-accounts__table-head {
-  grid:
-    auto /
-    minmax(2rem, 0.5fr)
-    minmax(8rem, 5fr)
-    minmax(8rem, 2fr)
-    minmax(8rem, 2fr)
-    minmax(8rem, 1.5fr);
 }
 @include respond-to(tablet) {
   .top-accounts__table-head {

--- a/src/views/TransactionsView.vue
+++ b/src/views/TransactionsView.vue
@@ -108,3 +108,11 @@ onMounted(async () => {
   await getTransactions()
 })
 </script>
+
+<style lang="scss" scoped>
+@include respond-to(medium) {
+  .app-table__head {
+    display: none;
+  }
+}
+</style>

--- a/src/views/TransactionsView.vue
+++ b/src/views/TransactionsView.vue
@@ -24,24 +24,26 @@
           {{ item.title }}
         </span>
       </div>
-      <template v-if="transactions?.length">
-        <TxLine
-          v-for="(item, index) in transactions"
-          :key="index"
-          :transition="item"
-        />
-      </template>
-      <template v-else>
-        <SkeletonTable
-          v-if="isLoading"
-          :header-titles="headerTitles"
-          table-size="10"
-          class-string="data-sources__table-row"
-        />
-        <div v-else class="app-table__empty-stub">
-          <p class="empty mg-t32">No items yet</p>
-        </div>
-      </template>
+      <div>
+        <template v-if="transactions?.length">
+          <TxLine
+            v-for="(item, index) in transactions"
+            :key="index"
+            :transition="item"
+          />
+        </template>
+        <template v-else>
+          <SkeletonTable
+            v-if="isLoading"
+            :header-titles="headerTitles"
+            table-size="10"
+            class-string="data-sources__table-row"
+          />
+          <div v-else class="app-table__empty-stub">
+            <p class="empty mg-t32">No items yet</p>
+          </div>
+        </template>
+      </div>
     </div>
 
     <AppPagination

--- a/src/views/ValidatorItem.vue
+++ b/src/views/ValidatorItem.vue
@@ -191,6 +191,7 @@ onMounted(async () => {
   @include ellipsis();
   line-height: 4.6rem;
 }
+
 @include respond-to(tablet) {
   .validators-item__title-wrapper {
     align-items: flex-start;

--- a/src/views/ValidatorsView.vue
+++ b/src/views/ValidatorsView.vue
@@ -5,7 +5,7 @@
   >
     <div class="app__main-view-table-header">
       <div class="app__main-view-table-header-prefix">
-        <span>Va</span>
+        <span>Vd</span>
       </div>
       <div class="app__main-view-table-header-info">
         <h3 class="app__main-view-table-header-info-title">Validators</h3>
@@ -320,34 +320,38 @@ onUnmounted(async () => {
 .validators-view__filter-search {
   display: flex;
   align-items: center;
-  background-color: var(--clr__light-gray-1);
+  background-color: var(--clr__dark);
   border-radius: 0.8rem;
-  color: var(--clr__input-border);
   transition: all 0.5s ease;
 
   svg {
     transition: all 0.5s ease;
-    fill: var(--clr__text-muted);
+    fill: var(--clr__white);
   }
+
   &:hover,
   &:active,
   &:focus,
   &:focus-within {
-    color: var(--clr__text);
-    border-color: var(--clr__text);
+    color: var(--clr__white);
+    border-color: var(--clr__white);
+
     svg {
       fill: var(--clr__text);
     }
   }
+
   &:disabled {
     border-color: var(--clr__input-border);
     color: var(--clr__input-border);
+
     svg {
       fill: var(--clr__input-border);
     }
   }
+
   svg.validators__filter-search-clear-btn-icon {
-    fill: var(--clr__text-muted);
+    fill: var(--clr__white);
   }
 }
 .validators-view__filter-search-input-wrapper {


### PR DESCRIPTION
Restyle layout for the following pages:

- Transactions
- Blocks
- Validators
- Top Accounts

<img width="1728" alt="Screenshot 2022-08-24 at 22 24 04" src="https://user-images.githubusercontent.com/29440427/186506687-f471a847-8929-47b1-bd80-62ece9e1420d.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 19" src="https://user-images.githubusercontent.com/29440427/186506706-4894b44a-a3cf-4e06-b8ba-733f69492ed3.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 31" src="https://user-images.githubusercontent.com/29440427/186506712-b75124e7-5de7-44e5-a96b-e3fa27adb5e5.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 43" src="https://user-images.githubusercontent.com/29440427/186506714-708a212c-b13c-4431-acde-6c5c10f63056.png">
<img width="1728" alt="Screenshot 2022-08-24 at 22 24 52" src="https://user-images.githubusercontent.com/29440427/186506717-3a7bf6ac-5f23-4198-b46c-eedbd4a88125.png">

